### PR TITLE
Pass chromedriver path in settings

### DIFF
--- a/attbillsplitter/main.py
+++ b/attbillsplitter/main.py
@@ -5,6 +5,7 @@ persists data in database.
 """
 
 import logging
+import os
 import re
 import sys
 import peewee as pw
@@ -66,10 +67,14 @@ class AttBillSpliter(object):
         'myworld?actionType=ViewBillHistory'
     )
 
-    def __init__(self, username, password):
+    def __init__(self, username, password, chromedriver = None):
         self.username = username
         self.password = password
-        self.browser = webdriver.Chrome()
+        if chromedriver is not None:
+            os.environ["webdriver.chrome.driver"] = chromedriver
+            self.browser = webdriver.Chrome(chromedriver)
+        else:
+            self.browser = webdriver.Chrome()
 
     def try_click_no_on_popup(self):
         """Try to click on 'No' button on a page.
@@ -544,7 +549,11 @@ class AttBillSpliter(object):
 def run_split_bill():
     """Worker for parsing the website and splitting the bill."""
     create_tables_if_not_exist()
-    bill_splitter = AttBillSpliter(settings.username, settings.password)
+    bill_splitter = AttBillSpliter(
+        settings.username,
+        settings.password,
+        settings.chromedriver,
+    )
     lags = [int(lag) for lag in sys.argv[1:]]
     bill_splitter.run(lags)
     db.close()

--- a/attbillsplitter/main.py
+++ b/attbillsplitter/main.py
@@ -67,7 +67,7 @@ class AttBillSpliter(object):
         'myworld?actionType=ViewBillHistory'
     )
 
-    def __init__(self, username, password, chromedriver = None):
+    def __init__(self, username, password, chromedriver=None):
         self.username = username
         self.password = password
         if chromedriver is not None:

--- a/attbillsplitter/settings.py
+++ b/attbillsplitter/settings.py
@@ -10,6 +10,12 @@ twilio_auth_token = 'your_twilio_auth_token'
 username = 'your_att_user_name'
 password = 'your_att_password'
 
+# chromedriver path (optional)
+# suggested fix for
+# selenium.common.exceptions.WebDriverException:
+# Message: 'chromedriver' executable needs to be in PATH.
+chromedriver = "/your/path/to/chromedriver"
+
 # config
 # number of seconds to wait for the billing page to load
 # increase this number if the internet is slow

--- a/attbillsplitter/settings.py
+++ b/attbillsplitter/settings.py
@@ -14,7 +14,7 @@ password = 'your_att_password'
 # suggested fix for
 # selenium.common.exceptions.WebDriverException:
 # Message: 'chromedriver' executable needs to be in PATH.
-chromedriver = "/your/path/to/chromedriver"
+chromedriver = None # "/your/path/to/chromedriver"
 
 # config
 # number of seconds to wait for the billing page to load


### PR DESCRIPTION
Pass chromedriver path to AttBillSpliter as optional variable.
Fix potential issue with "'chromedriver' executable needs to be in PATH".
