### PR TITLE
skip promo popup when logging in

### DIFF
--- a/attbillsplitter/main.py
+++ b/attbillsplitter/main.py
@@ -141,15 +141,26 @@ class AttBillSplitter(object):
             return True
         else:
             if 'promo' in login_submit.url.lower():
-                print ('\U0001F534  Popup window detected during login. '
+                reject_status = self.clickSkipPromo()
+
+                if reject_status == False:
+                    print ('\U0001F534  Popup window detected during login. '
                        'Please login you account in a browser and click '
                        'through. Log out your account before you retry. '
                        '(Sometimes you might have to do this multiple times.')
-                return False
+
+                return reject_status
 
             print('\U0001F6AB  Login failed. Please check your username and '
                   'password and retry. Or something unexpected happened.')
             return False
+
+    def clickSkipPromo(self):
+        reject_promo_link = (
+            'https://www.att.com/olam/rejectPromoUserResponse.myworld',
+        )
+        skip_promo = self.session.get(reject_promo_link, params={'response':'rejected', 'reportActionEvent':'A_LGN_PROMO_DECLINED_SUB'})
+        return skip_promo.status_code == requests.codes.ok
 
     def get_history_bills(self):
         """Get history bills.

--- a/attbillsplitter/main.py
+++ b/attbillsplitter/main.py
@@ -143,7 +143,7 @@ class AttBillSplitter(object):
             if 'promo' in login_submit.url.lower():
                 reject_status = self.clickSkipPromo()
 
-                if reject_status == False:
+                if not reject_status:
                     print ('\U0001F534  Popup window detected during login. '
                        'Please login you account in a browser and click '
                        'through. Log out your account before you retry. '
@@ -155,11 +155,19 @@ class AttBillSplitter(object):
                   'password and retry. Or something unexpected happened.')
             return False
 
-    def clickSkipPromo(self):
+    def click_skip_promo(self):
+        """Request to skip the promo popup
+
+        :returns: status of the skip request (True or False)
+        :rtype: bool
+        """
         reject_promo_link = (
             'https://www.att.com/olam/rejectPromoUserResponse.myworld',
         )
-        skip_promo = self.session.get(reject_promo_link, params={'response':'rejected', 'reportActionEvent':'A_LGN_PROMO_DECLINED_SUB'})
+        skip_promo = self.session.get(reject_promo_link, params={
+            'response': 'rejected',
+            'reportActionEvent': 'A_LGN_PROMO_DECLINED_SUB'
+        })
         return skip_promo.status_code == requests.codes.ok
 
     def get_history_bills(self):

--- a/attbillsplitter/main.py
+++ b/attbillsplitter/main.py
@@ -141,15 +141,13 @@ class AttBillSplitter(object):
             return True
         else:
             if 'promo' in login_submit.url.lower():
-                reject_status = self.clickSkipPromo()
-
-                if not reject_status:
+                if not self.click_skip_promo():
                     print ('\U0001F534  Popup window detected during login. '
                        'Please login you account in a browser and click '
                        'through. Log out your account before you retry. '
                        '(Sometimes you might have to do this multiple times.')
-
-                return reject_status
+                    return False
+                return True
 
             print('\U0001F6AB  Login failed. Please check your username and '
                   'password and retry. Or something unexpected happened.')


### PR DESCRIPTION
Added a get request which effectively skips the promotion page.

I couldn't seem to make login work by opening a browser and logging in before using this splitter. Instead I've tweaked the login process such that it will skip the promotion page for the user automatically.